### PR TITLE
Improving basic auth

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    skull_island (1.2.6)
+    skull_island (1.2.7)
       deepsort (~> 0.4)
       erubi (~> 1.8)
       json (~> 2.1)

--- a/lib/skull_island/resources/basicauth_credential.rb
+++ b/lib/skull_island/resources/basicauth_credential.rb
@@ -5,7 +5,7 @@ module SkullIsland
   module Resources
     # The BasicauthCredential resource class
     #
-    # @see https://docs.konghq.com/hub/kong-inc/key-auth/ Key-Auth API definition
+    # @see https://docs.konghq.com/hub/kong-inc/basic-auth/ Basic-Auth API definition
     class BasicauthCredential < Resource
       attr_accessor :hashed_password
 

--- a/lib/skull_island/resources/basicauth_credential.rb
+++ b/lib/skull_island/resources/basicauth_credential.rb
@@ -69,7 +69,7 @@ module SkullIsland
         hash.reject { |_, value| value.nil? }
       end
 
-      # Keys can't be updated, only deleted then created
+      # Credentials can't be updated, only deleted then created
       def modified_existing?
         return false unless new?
 

--- a/lib/skull_island/resources/basicauth_credential.rb
+++ b/lib/skull_island/resources/basicauth_credential.rb
@@ -7,8 +7,10 @@ module SkullIsland
     #
     # @see https://docs.konghq.com/hub/kong-inc/key-auth/ Key-Auth API definition
     class BasicauthCredential < Resource
+      attr_accessor :hashed_password
+
       property :username, required: true, validate: true
-      property :password, validated: true
+      property :password, validated: true, preprocess: true, postprocess: true
       property(
         :consumer,
         required: true, validate: true, preprocess: true, postprocess: true
@@ -44,6 +46,17 @@ module SkullIsland
         consumer ? "#{consumer.relative_uri}/basic-auth" : nil
       end
 
+      def digest
+        Digest::MD5.hexdigest(
+          if new? && !password.match?(/^hash{.+}$/)
+            hashed_pass = Digest::SHA1.hexdigest((password || '') + consumer.id)
+            "#{username}:hash{#{hashed_pass}}"
+          else
+            "#{username}:#{password}"
+          end
+        )
+      end
+
       def export(options = {})
         hash = { 'username' => username, 'password' => password }
         hash['consumer'] = "<%= lookup :consumer, '#{consumer.username}' %>" if consumer
@@ -56,13 +69,39 @@ module SkullIsland
         hash.reject { |_, value| value.nil? }
       end
 
-      # Keys can't be updated, only created or deleted
+      # Keys can't be updated, only deleted then created
       def modified_existing?
-        false
+        return false unless new?
+
+        # Find credentials of the same username
+        basic_auths = consumer.credentials['basic-auth']
+        return false unless basic_auths
+
+        same_username = basic_auths.where(:username, username)
+
+        existing = same_username.size == 1 ? same_username.first : nil
+        # Need to destroy the old one then save the new one...
+        existing ? existing.destroy && save : false
       end
 
       def project
         consumer ? consumer.project : nil
+      end
+
+      def <=>(other)
+        if id
+          if id < other.id
+            -1
+          elsif id > other.id
+            1
+          elsif id == other.id
+            0
+          else
+            raise Exceptions::InvalidArguments
+          end
+        else
+          digest <=> other.digest
+        end
       end
 
       private
@@ -84,6 +123,19 @@ module SkullIsland
           input
         else
           { 'id' => input.id }
+        end
+      end
+
+      def postprocess_password(value)
+        hashed_password || !new? ? "hash{#{value}}" : value
+      end
+
+      def preprocess_password(input)
+        if input.match?(/^hash{.+}$/)
+          @hashed_password = true
+          input.match(/^hash{(.+)}$/)[1]
+        else
+          input
         end
       end
 

--- a/lib/skull_island/version.rb
+++ b/lib/skull_island/version.rb
@@ -4,6 +4,6 @@ module SkullIsland
   VERSION = [
     1, # Major
     2, # Minor
-    6  # Patch
+    7  # Patch
   ].join('.')
 end


### PR DESCRIPTION
Addresses #4, at least partially. Dumping basic-auth passwords isn't really possible as they're one-way hashed via a salted SHA1, but at least this allows the expected handling of basic-auth passwords using the `import` functionality.