### PR TITLE
Simple support for API pagination on GET

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    skull_island (1.2.9)
+    skull_island (1.2.10)
       deepsort (~> 0.4)
       erubi (~> 1.8)
       json (~> 2.1)

--- a/lib/skull_island/version.rb
+++ b/lib/skull_island/version.rb
@@ -4,6 +4,6 @@ module SkullIsland
   VERSION = [
     1, # Major
     2, # Minor
-    9  # Patch
+    10 # Patch
   ].join('.')
 end


### PR DESCRIPTION
While this doesn't use an Enumerable, this addresses #9. An Enumerable would require some changes to how data is extracted from the JSON response since it is embedded under a 'data' key but the _entire_ parsed response is what is returned from the `APIClientBase#get()` method. That said, the current approach, while not optimal, should work in all but the most extreme examples (very large responses).