### PR TITLE
Updating API Client testing to use subclass

### DIFF
--- a/lib/skull_island/rspec.rb
+++ b/lib/skull_island/rspec.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
+require 'skull_island/rspec/fake_client/request'
+require 'skull_island/rspec/fake_rest_client'
 require 'skull_island/rspec/fake_api_client'

--- a/lib/skull_island/rspec/fake_api_client.rb
+++ b/lib/skull_island/rspec/fake_api_client.rb
@@ -3,13 +3,7 @@
 module SkullIsland
   module RSpec
     # A Fake API Client for RSpec testing
-    class FakeAPIClient
-      attr_reader :server, :base_uri
-      attr_accessor :username, :password
-
-      include Validations::APIClient
-      include Helpers::APIClient
-
+    class FakeAPIClient < APIClientBase
       def initialize(opts = {})
         # validations
         validate_opts(opts)
@@ -22,39 +16,12 @@ module SkullIsland
         @configured = true
       end
 
-      def hash(data)
-        if data
-          Digest::MD5.hexdigest(data.sort.to_s)
-        else
-          ''
-        end
-      end
-
       def response_for(type, uri, data: nil, response: {})
-        @responses ||= {}
-        @responses[type.to_s] ||= {}
-        key = data ? uri.to_s + hash(data) : uri.to_s
-        @responses[type.to_s][key] = response
+        connection.response_for(type, uri, data: data, response: response)
       end
 
-      def get(uri, _data = nil)
-        @responses ||= {}
-        @responses.dig('get', uri.to_s)
-      end
-
-      def post(uri, data = nil)
-        @responses ||= {}
-        @responses.dig('post', uri.to_s + hash(data))
-      end
-
-      def patch(uri, data)
-        @responses ||= {}
-        @responses.dig('patch', uri.to_s + hash(data))
-      end
-
-      def put(uri, data)
-        @responses ||= {}
-        @responses.dig('put', uri.to_s + hash(data))
+      def connection
+        @connection ||= FakeRestClient.new
       end
     end
   end

--- a/lib/skull_island/rspec/fake_client/request.rb
+++ b/lib/skull_island/rspec/fake_client/request.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module SkullIsland
+  module RSpec
+    module FakeClient
+      # A Fake Rest Client Request for RSpec testing
+      class Request
+        attr_reader :uri
+
+        def initialize(rest_client, uri)
+          @rest_client = rest_client
+          @uri = uri
+        end
+
+        def hash(data)
+          @rest_client.hash(JSON.parse(data))
+        end
+
+        def responses
+          @rest_client.responses
+        end
+
+        def get(_data = nil, _opts = nil)
+          responses.dig('get', uri.to_s)
+        end
+
+        def post(data = nil, _opts = nil)
+          responses.dig('post', uri.to_s + hash(data))
+        end
+
+        def patch(data, _opts = nil)
+          responses.dig('patch', uri.to_s + hash(data))
+        end
+
+        def put(data, _opts = nil)
+          responses.dig('put', uri.to_s + hash(data))
+        end
+      end
+    end
+  end
+end

--- a/lib/skull_island/rspec/fake_rest_client.rb
+++ b/lib/skull_island/rspec/fake_rest_client.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module SkullIsland
+  module RSpec
+    # A Fake Rest Client for RSpec testing
+    class FakeRestClient
+      attr_reader :responses
+
+      def initialize
+        @responses = {}
+      end
+
+      def hash(data)
+        if data
+          Digest::MD5.hexdigest(data.sort.to_s)
+        else
+          ''
+        end
+      end
+
+      def response_for(type, uri, data: nil, response: {})
+        @responses[type.to_s] ||= {}
+        key = data ? uri.to_s + hash(data) : uri.to_s
+        @responses[type.to_s][key] = JSON.dump(response)
+      end
+
+      def [](uri)
+        FakeClient::Request.new(self, uri)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Complicates testing just a bit, but uses a subclass of APIClientBase, which allows testing a lot more of the functionality of the actual API client.