### PR TITLE
thor 0.20 -> 1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       json (~> 2.1)
       linguistics (~> 2.1)
       rest-client (~> 2.1)
-      thor (~> 0.20)
+      thor (~> 1.0.0)
       will_paginate (~> 3.1)
 
 GEM
@@ -59,7 +59,7 @@ GEM
       addressable (~> 2.3)
     linguistics (2.1.0)
       loggability (~> 0.11)
-    loggability (0.17.0)
+    loggability (0.18.2)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
@@ -120,7 +120,7 @@ GEM
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    thor (0.20.3)
+    thor (1.0.1)
     thread_safe (0.3.6)
     tins (1.26.0)
       sync

--- a/skull_island.gemspec
+++ b/skull_island.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json', '~> 2.1'
   spec.add_runtime_dependency 'linguistics', '~> 2.1'
   spec.add_runtime_dependency 'rest-client', '~> 2.1'
-  spec.add_runtime_dependency 'thor', '~> 0.20'
+  spec.add_runtime_dependency 'thor', '~> 1.0.0'
   spec.add_runtime_dependency 'will_paginate', '~> 3.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/skull_island.gemspec
+++ b/skull_island.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json', '~> 2.1'
   spec.add_runtime_dependency 'linguistics', '~> 2.1'
   spec.add_runtime_dependency 'rest-client', '~> 2.1'
-  spec.add_runtime_dependency 'thor', '~> 1.0.0'
+  spec.add_runtime_dependency 'thor', '~> 1.0'
   spec.add_runtime_dependency 'will_paginate', '~> 3.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
`railties` gem for Rails 6.1.1 started to depend on `thor` 1.0.

As far as I see the only breaking change is `thor` 1.0 no longer supports Ruby < 2 https://github.com/erikhuda/thor/blob/master/CHANGELOG.md