### PR TITLE
Resource.from_hash was missing a parameter

### DIFF
--- a/lib/skull_island/resource.rb
+++ b/lib/skull_island/resource.rb
@@ -122,7 +122,7 @@ module SkullIsland
       )
     end
 
-    def self.from_hash(hash)
+    def self.from_hash(hash, options = {})
       # TODO: better options validations
       raise Exceptions::InvalidOptions unless options.is_a?(Hash)
 


### PR DESCRIPTION
It looks like the method never worked.

It's used by `UpstreamTarget.from_hash(details, api_client: api_client)` and ` Route.from_hash(details, api_client: api_client)`