### PR TITLE
Ruby 3.0 and Kong 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.0
   NewCops: enable
 
 Metrics/MethodLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.5
-- 2.6
-- 2.7
-before_install: gem install bundler -v '~> 2.0'
+- 3.0
+before_install: gem install bundler -v '~> 2.2'
 deploy:
   provider: rubygems
   api_key:
@@ -12,5 +10,5 @@ deploy:
   gem: skull_island
   on:
     tags: true
-    rvm: 2.6
+    rvm: 3.0
     repo: jgnagy/skull_island

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5-alpine
+FROM ruby:3.0-alpine
 LABEL maintainer="Jonathan Gnagy <jonathan.gnagy@gmail.com>"
 
 COPY . /install

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    skull_island (2.2.2)
+    skull_island (2.3.0)
       deepsort (~> 0.4)
       erubi (~> 1.8)
-      json (~> 2.1)
       linguistics (~> 2.1)
       rest-client (~> 2.1)
       thor (~> 1.0)
       will_paginate (~> 3.1)
+      yajl-ruby (~> 1.4)
 
 GEM
   remote: https://rubygems.org/
@@ -142,6 +142,7 @@ GEM
     unicode-display_width (1.7.0)
     websocket (1.2.9)
     will_paginate (3.3.0)
+    yajl-ruby (1.4.1)
     yard (0.9.26)
 
 PLATFORMS
@@ -159,4 +160,4 @@ DEPENDENCIES
   yard (~> 0.9.20)
 
 BUNDLED WITH
-   2.2.6
+   2.2.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,12 +22,11 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     concurrent-ruby (1.1.8)
-    coveralls (0.7.1)
-      multi_json (~> 1.3)
-      rest-client
-      simplecov (>= 0.7)
-      term-ansicolor
-      thor
+    coveralls_reborn (0.20.0)
+      simplecov (>= 0.18.1, < 0.22.0)
+      term-ansicolor (~> 1.6)
+      thor (>= 0.20.3, < 2.0)
+      tins (~> 1.16)
     deepsort (0.4.5)
     diff-lcs (1.4.4)
     docile (1.3.5)
@@ -150,11 +149,11 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  coveralls (~> 0.7)
+  coveralls_reborn (~> 0.20)
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 0.50)
-  simplecov (~> 0.17)
+  simplecov (~> 0.21)
   skull_island!
   travis (~> 1.8)
   yard (~> 0.9.20)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Skull Island
 
-A full-featured SDK for [Kong](https://konghq.com/kong/) 2.2.x (with support 2.0.x and 2.1.x, and for migrating from 0.14.x, 1.1.x, 1.2.x, 1.4.x, and 1.5.x). Note that this is unofficial (meaning this project is in no way officially endorsed, recommended, or related to Kong [as a company](https://konghq.com/) or an [open-source project](https://github.com/Kong/kong)). It is also in no way related to the [pet toy company](https://www.kongcompany.com/) by the same name (but hopefully that was obvious).
+A full-featured SDK for [Kong](https://konghq.com/kong/) 2.3.x (with support 2.0.x, 2.1.x, and 2.2.x, and for migrating from 0.14.x, 1.1.x, 1.2.x, 1.4.x, and 1.5.x). Note that this is unofficial (meaning this project is in no way officially endorsed, recommended, or related to Kong [as a company](https://konghq.com/) or an [open-source project](https://github.com/Kong/kong)). It is also in no way related to the [pet toy company](https://www.kongcompany.com/) by the same name (but hopefully that was obvious).
 
 ![Gem](https://img.shields.io/gem/v/skull_island)
 ![Travis (.org)](https://img.shields.io/travis/jgnagy/skull_island)
@@ -21,7 +21,9 @@ skull_island help
 
 ### Ruby Gem Install / SDK
 
-Either:
+**Note:** Starting with 2.3.0, Skull Island only supports Ruby 3.0+. If you need to use Ruby 2.x, you'll need to use a gem version < 2.3.0. I'll maintain the 2.2.x line for Ruby 2.x compatibility for 2021.
+
+To use the Skull Island gem, either:
 
 ```sh
 gem install skull_island
@@ -30,7 +32,7 @@ gem install skull_island
 Or add this to your Gemfile:
 
 ```ruby
-gem 'skull_island',  '~> 2.2'
+gem 'skull_island',  '~> 2.3'
 ```
 
 Or add this to your .gemspec:
@@ -38,7 +40,7 @@ Or add this to your .gemspec:
 ```ruby
 Gem::Specification.new do |spec|
  # ...
- spec.add_runtime_dependency 'skull_island', '~> 2.2'
+ spec.add_runtime_dependency 'skull_island', '~> 2.3'
  # ...
 end
 ```
@@ -149,7 +151,7 @@ When using the `project` feature of Skull Island, the CLI tool will automaticall
 
 ### Migrating
 
-With Skull Island, it is possible to migrate a configuration from a 0.14.x, 1.1.x, 1.2.x, 1.4.x, or 1.5.x gateway to the most recent compatible gateway. If you have a previous export, you can just run `skull_island migrate /path/to/export.yml` and you'll receive a 2.2 compatible config on standard out. If you'd prefer, you can have that config written to a file as well (just like the export command) like so:
+With Skull Island, it is possible to migrate a configuration from a 0.14.x, 1.1.x, 1.2.x, 1.4.x, or 1.5.x gateway to the most recent compatible gateway. If you have a previous export, you can just run `skull_island migrate /path/to/export.yml` and you'll receive a 2.3 compatible config on standard out. If you'd prefer, you can have that config written to a file as well (just like the export command) like so:
 
 ```sh
 skull_island migrate /path/to/export.yml /output/location/migrated.yml
@@ -159,7 +161,7 @@ While this hasn't been heavily tested for all possible use-cases, any configurat
 
 If you don't have a previous export, you'll need to install an older version of this gem using something like `gem install --version '~> 0.14' skull_island`, then perform an `export`, then you can switch back to the latest version of the gem for migrating and importing.
 
-While it would be possible to make migration _automatic_ for the `import` command, `skull_island` intentionally doesn't do this to avoid the appearance that the config is losslessly compatible across versions. In reality, the newer config version has additional features (like tagging) that are used heavily by skull_island. It makes sense to this author to maintain the migration component and the normal functionality as distinct features to encourage the use of the newer capabilities in 1.1 and beyond. That said, Skull Island does allow 1.x, 2.0.x, and 2.1.x version configurations to be applied to 2.2 gateways, but not the opposite.
+While it would be possible to make migration _automatic_ for the `import` command, `skull_island` intentionally doesn't do this to avoid the appearance that the config is losslessly compatible across versions. In reality, the newer config version has additional features (like tagging) that are used heavily by skull_island. It makes sense to this author to maintain the migration component and the normal functionality as distinct features to encourage the use of the newer capabilities in 1.1 and beyond. That said, Skull Island does allow 1.x, 2.0.x, 2.1.x, and 2.2.x version configurations to be applied to 2.3 gateways, but not the opposite.
 
 ### Reset A Gateway
 
@@ -188,7 +190,7 @@ If you're wondering what version of `skull_island` is installed, use:
 ```sh
 $ skull_island version
 
-SkullIsland Version: 2.2.0
+SkullIsland Version: 2.3.0
 ```
 
 ### File Format
@@ -197,7 +199,7 @@ The import/export/migrate CLI functions produce YAML with support for embedded R
 
 ```yaml
 ---
-version: '2.2'
+version: '2.3'
 project: FooV2
 certificates: []
 ca_certificates:

--- a/lib/skull_island.rb
+++ b/lib/skull_island.rb
@@ -9,7 +9,6 @@ Hash.include CoreExtensions::Hash::Pruning
 # Standard Library Requirements
 require 'date'
 require 'digest'
-require 'json'
 require 'singleton'
 require 'uri'
 require 'yaml'
@@ -22,6 +21,7 @@ Linguistics.use(:en)
 require 'rest-client'
 require 'will_paginate'
 require 'will_paginate/array'
+require 'yajl/json_gem'
 
 # Internal Requirements
 require 'skull_island/version'

--- a/lib/skull_island/version.rb
+++ b/lib/skull_island/version.rb
@@ -3,7 +3,7 @@
 module SkullIsland
   VERSION = [
     2, # Major
-    2, # Minor
-    2  # Patch
+    3, # Minor
+    0  # Patch
   ].join('.')
 end

--- a/skull_island.gemspec
+++ b/skull_island.gemspec
@@ -35,11 +35,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'yajl-ruby', '~> 1.4'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'coveralls', '~> 0.7'
+  spec.add_development_dependency 'coveralls_reborn', '~> 0.20'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.50'
-  spec.add_development_dependency 'simplecov', '~> 0.17'
+  spec.add_development_dependency 'simplecov', '~> 0.21'
   spec.add_development_dependency 'travis', '~> 1.8'
   spec.add_development_dependency 'yard', '~> 0.9.20'
 end

--- a/skull_island.gemspec
+++ b/skull_island.gemspec
@@ -24,15 +24,15 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = '~> 3.0'
 
   spec.add_runtime_dependency 'deepsort', '~> 0.4'
   spec.add_runtime_dependency 'erubi', '~> 1.8'
-  spec.add_runtime_dependency 'json', '~> 2.1'
   spec.add_runtime_dependency 'linguistics', '~> 2.1'
   spec.add_runtime_dependency 'rest-client', '~> 2.1'
   spec.add_runtime_dependency 'thor', '~> 1.0'
   spec.add_runtime_dependency 'will_paginate', '~> 3.1'
+  spec.add_runtime_dependency 'yajl-ruby', '~> 1.4'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'coveralls', '~> 0.7'


### PR DESCRIPTION
Switching to Ruby 3.0. Support for Ruby 2.6 and 2.7 will be maintained for the remainder of 2021 via the 2.2.x release line/the `pre-2.3` branch.

**This is important**, if you're still on Ruby 2.x, you must stick with the 2.2.x line of skull_island:

```ruby
gem 'skull_island',  '~> 2.2.2  # only uses 2.2.x'
```

This PR also switches the JSON library to [`yajl`](https://github.com/brianmario/yajl-ruby) to speed things up even more. Performance should be significantly improved.

Finally, this adds support for [Kong 2.3](https://konghq.com/blog/kong-gateway-2-3-released/).