### PR TITLE
Adding render option to apply preprocessing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    skull_island (2.3.3)
+    skull_island (2.3.4)
       deepsort (~> 0.4)
       erubi (~> 1.8)
       linguistics (~> 2.1)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Commands:
   skull_island help [COMMAND]                          # Describe available commands or one specific command
   skull_island import [OPTIONS] [INPUT|-]              # Import a configuration from INPUT
   skull_island migrate [OPTIONS] [INPUT|-] [OUTPUT|-]  # Migrate an older config from INPUT to OUTPUT
+  skull_island render [INPUT|-]                        # Render out preprocessed YAML for troubleshooting
   skull_island reset                                   # Fully reset a gateway (removing all config)
   skull_island version                                 # Display the current installed version of skull_island
 
@@ -148,6 +149,16 @@ Skull Island 1.2.1 introduced the ability to use a special top-level key in the 
 To use this functionality, either add the `project` key to your configuration file (usually directly below the `version` key) with some value that will be unique on your gateway, or use `--project foo` (where `foo` is the name of your project) as a CLI flag.
 
 When using the `project` feature of Skull Island, the CLI tool will automatically clean up old resources no longer found in your config file. This is, in fact, the _only_ circumstance under which this tool actually removes resources. Use this feature with care, as it can delete large swaths of your configuration if used incorrectly. It is **critical** that this value is unique since this project functionality is used to delete resources.
+
+#### Troubleshooting Import Failures
+
+If you're having trouble importing some YAML -- especially if you've done a lot of templating or have a lot of embedded ruby in your template -- you can use the `render` command to just output the raw, preprocessed YAML that Skull Island would attempt to import:
+
+```sh
+skull_island render /path/to/some/template.yml
+```
+
+This is safe to do on your local machine since it doesn't connect to a gateway. It will leave `lookup` functions but otherwise will leave the YAML without embedded ruby. This can then be linted with any YAML linter to help discover YAML-related formatting issues, etc., that cause import issues.
 
 ### Migrating
 

--- a/lib/skull_island/cli.rb
+++ b/lib/skull_island/cli.rb
@@ -132,6 +132,12 @@ module SkullIsland
       ].each { |clname| reset_class(clname, options['project']) }
     end
 
+    desc('render [INPUT|-]', 'Render out preprocessed YAML for troubleshooting')
+    def render(input_file = '-')
+      raw ||= acquire_input(input_file, options['verbose'])
+      puts erb_preprocess(raw)
+    end
+
     desc('version', 'Display the current installed version of skull_island')
     def version
       puts "SkullIsland Version: #{SkullIsland::VERSION}"

--- a/lib/skull_island/version.rb
+++ b/lib/skull_island/version.rb
@@ -4,6 +4,6 @@ module SkullIsland
   VERSION = [
     2, # Major
     3, # Minor
-    3  # Patch
+    4  # Patch
   ].join('.')
 end


### PR DESCRIPTION
Adds `skull_island render` option to help with troubleshooting YAML formatting issues for the CLI `import` command. Addresses #53 